### PR TITLE
Grails deployed on JBoss AS 7 don't handle 401 response correctly

### DIFF
--- a/src/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenAuthenticationEntryPoint.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenAuthenticationEntryPoint.groovy
@@ -40,11 +40,10 @@ class BearerTokenAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
         if (accessToken) {
             response.addHeader('WWW-Authenticate', 'Bearer error="invalid_token"')
-            response.status = HttpServletResponse.SC_UNAUTHORIZED
         } else {
             response.addHeader('WWW-Authenticate', 'Bearer')
-            response.status = HttpServletResponse.SC_UNAUTHORIZED
         }
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
 
     }
 }


### PR DESCRIPTION
Just setting status doesn't trigger server into using <error-page> entries in web.xml to handle error results which causes ugly default JBoss error page.

Other AuthenticationEntryPoint implementations use sendError method which is correct way of sending error response to the client.
